### PR TITLE
Update crossing-training.lic

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -140,7 +140,7 @@ class CrossingTraining
       end
 
       # Output a harmless command to prevent being logged out
-      fput 'tdp'
+      fput 'research status'
       return
     end
 


### PR DESCRIPTION
change Tdp on line 143 to Research status - just as harmless but shows actual needed information during research in a spam heavy room.